### PR TITLE
Patch endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -111,10 +111,16 @@ app.delete('/api/v1/palettes/:palette_name', (req, resp) => {
 
 app.patch('/api/v1/projects/:name', (request, response) => {
   const { name } = request.params;
-  database('projects').where({ name }).update({
-    name: request.body.name
-  })
-  .then(() => response.status(202).json({ message: `Project name changed to ${request.body.name}`}))
+  database('projects').where({ name })
+    .then(project => {
+      if (!project.length) {
+        return response.status(404).json({ error: `No existing project with ${name}`})
+      }
+      database('projects').where({ name }).update({
+        name: request.body.name
+      })
+    .then(() => response.status(202).json({ message: `Project name changed to ${request.body.name}`}))
+    })
   .catch((error) => response.status(500).json({ error }))
 })
 

--- a/app.js
+++ b/app.js
@@ -112,9 +112,9 @@ app.delete('/api/v1/palettes/:palette_name', (req, resp) => {
 app.patch('/api/v1/projects/:name', (request, response) => {
   const { name } = request.params;
   database('projects').where({ name })
-    .then(project => {
+    .then(project => {  
       if (!project.length) {
-        return response.status(404).json({ error: `No existing project with ${name}`})
+        return response.status(404).json({ error: `No existing project with name of ${name}`})
       }
       database('projects').where({ name }).update({
         name: request.body.name
@@ -122,6 +122,27 @@ app.patch('/api/v1/projects/:name', (request, response) => {
     .then(() => response.status(202).json({ message: `Project name changed to ${request.body.name}`}))
     })
   .catch((error) => response.status(500).json({ error }))
+})
+
+app.patch('/api/v1/palettes/:palette_name', async (request, response) => {
+  const { palette_name } = request.params
+  // const { color } = request.body
+  const selectedPalette = await database('palettes').where('palette_name', palette_name).select()
+  console.log('selected palette', selectedPalette)
+  const doesExist = selectedPalette.length ? true : false
+  console.log('exists', doesExist)
+  if (!doesExist) {
+    return response.status(404).json({ error: `No existing palette with name of ${palette_name}`})
+  }
+  for (let possibleParameter of ['color_1', 'color_2', 'color_3', 'color_4', 'color_5'] ) {
+    if (request.body[possibleParameter] && doesExist ) {
+      database('palettes').where({ palette_name }).update({
+        [possibleParameter]: request.body[possibleParameter]
+      })
+      .then(() => response.status(202).json({ message: 'Color updated'}))
+      .catch((error) => response.status(500).json({ error }))
+    }
+  }
 })
 
 export default app;

--- a/app.js
+++ b/app.js
@@ -112,38 +112,34 @@ app.delete('/api/v1/palettes/:palette_name', (req, resp) => {
 app.patch('/api/v1/projects/:name', (request, response) => {
   const { name } = request.params;
   database('projects').where({ name })
-    .then(project => {  
+    .then((project) => {
       if (!project.length) {
-        return response.status(404).json({ error: `No existing project with name of ${name}`})
+        return response.status(404).json({ error: `No existing project with name of ${name}` });
       }
       database('projects').where({ name }).update({
-        name: request.body.name
+        name: request.body.name,
       })
-    .then(() => response.status(202).json({ message: `Project name changed to ${request.body.name}`}))
+        .then(() => response.status(202).json({ message: `Project name changed to ${request.body.name}` }));
     })
-  .catch((error) => response.status(500).json({ error }))
-})
+    .catch((error) => response.status(500).json({ error }));
+});
 
 app.patch('/api/v1/palettes/:palette_name', async (request, response) => {
-  const { palette_name } = request.params
-  // const { color } = request.body
-  const selectedPalette = await database('palettes').where('palette_name', palette_name).select()
-  console.log('selected palette', selectedPalette)
-  const doesExist = selectedPalette.length ? true : false
-  console.log('exists', doesExist)
+  const { palette_name } = request.params;
+  const selectedPalette = await database('palettes').where('palette_name', palette_name).select();
+  const doesExist = selectedPalette.length ? true : false;
   if (!doesExist) {
-    return response.status(404).json({ error: `No existing palette with name of ${palette_name}`})
+    return response.status(404).json({ error: `No existing palette with name of ${palette_name}` });
   }
-  for (let possibleParameter of ['color_1', 'color_2', 'color_3', 'color_4', 'color_5'] ) {
-    if (request.body[possibleParameter] && doesExist ) {
-      console.log('param', possibleParameter)
+  for (const possibleParameter of ['color_1', 'color_2', 'color_3', 'color_4', 'color_5']) {
+    if (request.body[possibleParameter] && doesExist) {
       database('palettes').where({ palette_name }).update({
-        [possibleParameter]: request.body[possibleParameter]
+        [possibleParameter]: request.body[possibleParameter],
       })
-      .then(() => response.status(202).json({ message: 'Color updated'}))
-      .catch((error) => response.status(500).json({ error }))
+        .then(() => response.status(202).json({ message: 'Color updated' }))
+        .catch((error) => response.status(500).json({ error }));
     }
   }
-})
+});
 
 export default app;

--- a/app.js
+++ b/app.js
@@ -136,6 +136,7 @@ app.patch('/api/v1/palettes/:palette_name', async (request, response) => {
   }
   for (let possibleParameter of ['color_1', 'color_2', 'color_3', 'color_4', 'color_5'] ) {
     if (request.body[possibleParameter] && doesExist ) {
+      console.log('param', possibleParameter)
       database('palettes').where({ palette_name }).update({
         [possibleParameter]: request.body[possibleParameter]
       })

--- a/app.js
+++ b/app.js
@@ -109,4 +109,13 @@ app.delete('/api/v1/palettes/:palette_name', (req, resp) => {
     .catch((err) => resp.status(500).json({ err }));
 });
 
+app.patch('/api/v1/projects/:name', (request, response) => {
+  const { name } = request.params;
+  database('projects').where({ name }).update({
+    name: request.body.name
+  })
+  .then(() => response.status(202).json({ message: `Project name changed to ${request.body.name}`}))
+  .catch((error) => response.status(500).json({ error }))
+})
+
 export default app;

--- a/app.test.js
+++ b/app.test.js
@@ -163,32 +163,40 @@ describe('Server', () => {
 
   describe('PATCH /api/v1/projects/:name', () => {
     it('should return a 202 status and update the item', async () => {
-      const newName = { name: 'hi'}
-      const originalProject = await database('projects').where({ name: 'Super dope project'}).first()
-      expect(originalProject.name).toEqual('Super dope project')
-      const update = await request(app).patch(`/api/v1/projects/${originalProject.name}`).send(newName)
-      const updatedProject = await database('projects').where({name: 'hi'}).first()
-      expect(updatedProject.name).toEqual('hi')
-      expect(update.status).toBe(202)
-      expect(update.body.message).toEqual('Project name changed to hi')
-    })
-  })
+      const newName = { name: 'hi' };
+      const originalProject = await database('projects').where({ name: 'Super dope project' }).first();
+      expect(originalProject.name).toEqual('Super dope project');
+      const update = await request(app).patch(`/api/v1/projects/${originalProject.name}`).send(newName);
+      const updatedProject = await database('projects').where({ name: 'hi' }).first();
+      expect(updatedProject.name).toEqual('hi');
+      expect(update.status).toBe(202);
+      expect(update.body.message).toEqual('Project name changed to hi');
+    });
+    it('should return status 404 and error if not found', async() => {
+      const expected = 'No existing project with name of invalid';
+      const response = await request(app).patch('/api/v1/projects/invalid');
+      expect(response.body.error).toEqual(expected);
+      expect(response.status).toBe(404);
+    });
+  });
 
 
   describe('PATCH /api/v1/palettes/:palette_name', () => {
     it('should return a 202 status and update the color', async () => {
-      const newColor = { color_2: '#bbbbbb'}
-      const originalPalette = await database('palettes').where({ palette_name: 'super dope palette'}).first()
-      console.log('orig', originalPalette)
-      expect(originalPalette.palette_name).toEqual('super dope palette')
-      const update = await request(app).patch(`/api/v1/palettes/${originalPalette.palette_name}`).send(newColor)
-      // console.log('update', update)
-      const updatedPalette = await database('palettes').where({palette_name: 'super dope palette'}).first()
-      console.log('updated palette', updatedPalette)
-      console.log('color', updatedPalette.color_2)
-      expect(updatedPalette.color_2).toEqual('#bbbbbb')
-      // expect(update.status).toBe(202)
-      // expect(update.body.message).toEqual('Color updated')
-    })
-  })
+      const newColor = { color_2: '#bbbbbb' };
+      const originalPalette = await database('palettes').where({ palette_name: 'super dope palette' }).first();
+      expect(originalPalette.palette_name).toEqual('super dope palette');
+      const update = await request(app).patch(`/api/v1/palettes/${originalPalette.palette_name}`).send(newColor);
+      const updatedPalette = await database('palettes').where({ palette_name: 'super dope palette' }).first();
+      expect(updatedPalette.color_2).toEqual('#bbbbbb');
+      expect(update.status).toBe(202);
+      expect(update.body.message).toEqual('Color updated');
+    });
+    it('should return 404 and error msg if not found', async () => {
+      const expected = 'No existing palette with name of invalid';
+      const response = await request(app).patch('/api/v1/palettes/invalid');
+      expect(response.status).toBe(404);
+      expect(response.body.error).toEqual(expected);
+    });
+  });
 });

--- a/app.test.js
+++ b/app.test.js
@@ -181,7 +181,7 @@ describe('Server', () => {
       const originalPalette = await database('palettes').where({ palette_name: 'super dope palette'}).first()
       console.log('orig', originalPalette)
       expect(originalPalette.palette_name).toEqual('super dope palette')
-      const update = await request(app).patch(`/api/v1/palettes/${originalPalette.name}`).send(newColor)
+      const update = await request(app).patch(`/api/v1/palettes/${originalPalette.palette_name}`).send(newColor)
       // console.log('update', update)
       const updatedPalette = await database('palettes').where({palette_name: 'super dope palette'}).first()
       console.log('updated palette', updatedPalette)

--- a/app.test.js
+++ b/app.test.js
@@ -160,4 +160,17 @@ describe('Server', () => {
       });
     });
   });
+
+  describe('PATCH /api/v1/projects/:name', () => {
+    it('should return a 202 status and update the item', async () => {
+      const newName = { name: 'hi'}
+      const originalProject = await database('projects').where({ name: 'Super dope project'}).first()
+      expect(originalProject.name).toEqual('Super dope project')
+      const update = await request(app).patch(`/api/v1/projects/${originalProject.name}`).send(newName)
+      const updatedProject = await database('projects').where({name: 'hi'}).first()
+      expect(updatedProject.name).toEqual('hi')
+      expect(update.status).toBe(202)
+      expect(update.body.message).toEqual('Project name changed to hi')
+    })
+  })
 });

--- a/app.test.js
+++ b/app.test.js
@@ -173,4 +173,22 @@ describe('Server', () => {
       expect(update.body.message).toEqual('Project name changed to hi')
     })
   })
+
+
+  describe('PATCH /api/v1/palettes/:palette_name', () => {
+    it('should return a 202 status and update the color', async () => {
+      const newColor = { color_2: '#bbbbbb'}
+      const originalPalette = await database('palettes').where({ palette_name: 'super dope palette'}).first()
+      console.log('orig', originalPalette)
+      expect(originalPalette.palette_name).toEqual('super dope palette')
+      const update = await request(app).patch(`/api/v1/palettes/${originalPalette.name}`).send(newColor)
+      // console.log('update', update)
+      const updatedPalette = await database('palettes').where({palette_name: 'super dope palette'}).first()
+      console.log('updated palette', updatedPalette)
+      console.log('color', updatedPalette.color_2)
+      expect(updatedPalette.color_2).toEqual('#bbbbbb')
+      // expect(update.status).toBe(202)
+      // expect(update.body.message).toEqual('Color updated')
+    })
+  })
 });


### PR DESCRIPTION
#### What's this PR do?

Implements happy-path tests for PATCH endpoints for both projects and palettes.

#### Where should the reviewer start?

In the app.js file and the accompanying app.test.js file

#### How should this be manually tested?

Verify via Postman that PATCH works to update the name of a project and that individual colors can be updated on a palette (suggest testing with a color_1 and a color_3, for example).

#### Questions:

For the future when we have a front end, I'm wondering if it would be better to have our request params be an ID, which perhaps could be grabbed on a click event for the project or palette rather than a name (so for a project, there would be a button the user clicks to edit the name, that click grabs the ID of the palette to be edited and then would run the API call)?
